### PR TITLE
refactor: update Tenant model and serializers to use URL fields for d…

### DIFF
--- a/Backend/connectx_backend/tenants/models.py
+++ b/Backend/connectx_backend/tenants/models.py
@@ -8,9 +8,7 @@ class Tenant(models.Model):
     name = models.CharField(max_length=255, unique=True)
     email = models.EmailField(unique=True)
     password = models.CharField(max_length=255)  # Store hashed passwords
-    logo = models.ImageField(
-        upload_to="tenant_logos/", null=True, blank=True, max_length=500
-    )
+    logo = models.URLField(max_length=500, null=True, blank=True)
     phone = models.CharField(max_length=20, null=True, blank=True)
     address = models.TextField(null=True, blank=True)
     website_url = models.URLField(max_length=500, null=True, blank=True)
@@ -38,25 +36,17 @@ class Tenant(models.Model):
         default="pending",
     )
     tenant_verification_date = models.DateField(null=True, blank=True)
-    business_registration_certificate = models.FileField(
-        upload_to="business_registration_certificates/",
-        null=True,
-        blank=True,
-        max_length=500,
+    business_registration_certificate = models.URLField(
+        max_length=500, null=True, blank=True
     )
-    business_license = models.FileField(
-        upload_to="business_licenses/", null=True, blank=True, max_length=500
-    )
+    business_license = models.URLField(max_length=500, null=True, blank=True)
 
     # Tax Information
     tin_number = models.CharField(max_length=255, null=True, blank=True)
     vat_number = models.CharField(max_length=255, null=True, blank=True)
     tax_office_address = models.CharField(max_length=255, null=True, blank=True)
-    tax_registration_certificate = models.FileField(
-        upload_to="tax_registration_certificates/",
-        null=True,
-        blank=True,
-        max_length=500,
+    tax_registration_certificate = models.URLField(
+        max_length=500, null=True, blank=True
     )
 
     # Banking Information
@@ -64,18 +54,14 @@ class Tenant(models.Model):
     bank_account_number = models.CharField(max_length=255, null=True, blank=True)
     bank_account_name = models.CharField(max_length=255, null=True, blank=True)
     bank_branch = models.CharField(max_length=255, null=True, blank=True)
-    bank_statement = models.FileField(
-        upload_to="bank_statements/", null=True, blank=True, max_length=500
-    )
+    bank_statement = models.URLField(max_length=500, null=True, blank=True)
 
     # Mobile App Information
     mobileapp_url = models.URLField(max_length=500, null=True, blank=True)
     mobileapp_name = models.CharField(max_length=255, null=True, blank=True)
 
     # Identification Documents
-    id_card = models.FileField(
-        upload_to="id_cards/", null=True, blank=True, max_length=500
-    )
+    id_card = models.URLField(max_length=500, null=True, blank=True)
 
     # API Key
     api_key = models.CharField(max_length=100, unique=True, null=True, blank=True)

--- a/Backend/connectx_backend/tenants/permissions.py
+++ b/Backend/connectx_backend/tenants/permissions.py
@@ -31,6 +31,10 @@ class IsTenantOwner(permissions.BasePermission):
     Custom permission to only allow owners of a tenant to edit it.
     """
 
+    def has_permission(self, request, view):
+        # Check if user is authenticated and is an owner
+        return request.user.is_authenticated and request.user.role == "owner"
+
     def has_object_permission(self, request, view, obj):
         # Read permissions are allowed to any request,
         # so we'll always allow GET, HEAD or OPTIONS requests.

--- a/Backend/connectx_backend/tenants/serializers.py
+++ b/Backend/connectx_backend/tenants/serializers.py
@@ -39,7 +39,9 @@ class TenantCreateSerializer(serializers.ModelSerializer):
 
         # Handle file uploads
         if logo:
-            tenant.logo = upload_image(logo)
+            upload_result = upload_image(logo)
+            if upload_result["success"]:
+                tenant.logo = upload_result["url"]
         tenant.save()
 
         return tenant
@@ -47,6 +49,32 @@ class TenantCreateSerializer(serializers.ModelSerializer):
 
 class TenantSerializer(serializers.ModelSerializer):
     """Serializer for the Tenant model."""
+
+    # Override URL fields to accept file uploads
+    logo = serializers.FileField(required=False, write_only=True)
+    business_registration_certificate = serializers.FileField(
+        required=False, write_only=True
+    )
+    business_license = serializers.FileField(required=False, write_only=True)
+    tax_registration_certificate = serializers.FileField(
+        required=False, write_only=True
+    )
+    bank_statement = serializers.FileField(required=False, write_only=True)
+    id_card = serializers.FileField(required=False, write_only=True)
+
+    # Add read-only URL fields
+    logo_url = serializers.URLField(source="logo", read_only=True)
+    business_registration_certificate_url = serializers.URLField(
+        source="business_registration_certificate", read_only=True
+    )
+    business_license_url = serializers.URLField(
+        source="business_license", read_only=True
+    )
+    tax_registration_certificate_url = serializers.URLField(
+        source="tax_registration_certificate", read_only=True
+    )
+    bank_statement_url = serializers.URLField(source="bank_statement", read_only=True)
+    id_card_url = serializers.URLField(source="id_card", read_only=True)
 
     class Meta:
         model = Tenant
@@ -56,6 +84,7 @@ class TenantSerializer(serializers.ModelSerializer):
             "email",
             "password",
             "logo",
+            "logo_url",
             "phone",
             "address",
             "website_url",
@@ -71,19 +100,24 @@ class TenantSerializer(serializers.ModelSerializer):
             "tenant_verification_status",
             "tenant_verification_date",
             "business_registration_certificate",
+            "business_registration_certificate_url",
             "business_license",
+            "business_license_url",
             "tin_number",
             "vat_number",
             "tax_office_address",
             "tax_registration_certificate",
+            "tax_registration_certificate_url",
             "bank_name",
             "bank_account_number",
             "bank_account_name",
             "bank_branch",
             "bank_statement",
+            "bank_statement_url",
             "mobileapp_url",
             "mobileapp_name",
             "id_card",
+            "id_card_url",
             "api_key",
         ]
         read_only_fields = ["id", "api_key", "created_at", "updated_at", "is_verified"]
@@ -91,51 +125,7 @@ class TenantSerializer(serializers.ModelSerializer):
             "password": {"write_only": True, "required": False},
             "name": {"required": False},
             "email": {"required": False},
-            "logo": {"required": False},
-            "business_registration_certificate": {"required": False},
-            "business_license": {"required": False},
-            "tax_registration_certificate": {"required": False},
-            "bank_statement": {"required": False},
-            "id_card": {"required": False},
         }
-
-    def create(self, validated_data):
-        """Create a new tenant."""
-        # Handle file uploads if present
-        logo = validated_data.pop("logo", None)
-        business_registration_certificate = validated_data.pop(
-            "business_registration_certificate", None
-        )
-        business_license = validated_data.pop("business_license", None)
-        tax_registration_certificate = validated_data.pop(
-            "tax_registration_certificate", None
-        )
-        bank_statement = validated_data.pop("bank_statement", None)
-        id_card = validated_data.pop("id_card", None)
-
-        # Create tenant instance
-        tenant = super().create(validated_data)
-
-        # Handle file uploads
-        if logo:
-            tenant.logo = upload_image(logo)
-        if business_registration_certificate:
-            tenant.business_registration_certificate = upload_image(
-                business_registration_certificate
-            )
-        if business_license:
-            tenant.business_license = upload_image(business_license)
-        if tax_registration_certificate:
-            tenant.tax_registration_certificate = upload_image(
-                tax_registration_certificate
-            )
-        if bank_statement:
-            tenant.bank_statement = upload_image(bank_statement)
-        if id_card:
-            tenant.id_card = upload_image(id_card)
-        tenant.save()
-
-        return tenant
 
     def update(self, instance, validated_data):
         """Update a tenant."""
@@ -156,21 +146,34 @@ class TenantSerializer(serializers.ModelSerializer):
 
         # Handle file uploads
         if logo:
-            tenant.logo = upload_image(logo)
+            upload_result = upload_image(logo, folder="tenant_logos")
+            if upload_result["success"]:
+                tenant.logo = upload_result["url"]
         if business_registration_certificate:
-            tenant.business_registration_certificate = upload_image(
-                business_registration_certificate
+            upload_result = upload_image(
+                business_registration_certificate,
+                folder="business_registration_certificates",
             )
+            if upload_result["success"]:
+                tenant.business_registration_certificate = upload_result["url"]
         if business_license:
-            tenant.business_license = upload_image(business_license)
+            upload_result = upload_image(business_license, folder="business_licenses")
+            if upload_result["success"]:
+                tenant.business_license = upload_result["url"]
         if tax_registration_certificate:
-            tenant.tax_registration_certificate = upload_image(
-                tax_registration_certificate
+            upload_result = upload_image(
+                tax_registration_certificate, folder="tax_registration_certificates"
             )
+            if upload_result["success"]:
+                tenant.tax_registration_certificate = upload_result["url"]
         if bank_statement:
-            tenant.bank_statement = upload_image(bank_statement)
+            upload_result = upload_image(bank_statement, folder="bank_statements")
+            if upload_result["success"]:
+                tenant.bank_statement = upload_result["url"]
         if id_card:
-            tenant.id_card = upload_image(id_card)
+            upload_result = upload_image(id_card, folder="id_cards")
+            if upload_result["success"]:
+                tenant.id_card = upload_result["url"]
         tenant.save()
 
         return tenant

--- a/Backend/connectx_backend/users/permissions.py
+++ b/Backend/connectx_backend/users/permissions.py
@@ -1,16 +1,48 @@
 from rest_framework import permissions
 
+
 class IsTenantOwner(permissions.BasePermission):
     """
     Custom permission to allow only tenant admins to modify resources.
     """
 
     def has_permission(self, request, view):
-        return request.user.is_authenticated and (request.user.role == "owner" or request.user.role == "admin")
+        return request.user.is_authenticated and (
+            request.user.role == "owner" or request.user.role == "admin"
+        )
+
+
 class IsTenantMember(permissions.BasePermission):
     """
     custom permission to allow members to modify the resource
     """
-    def has_permission(self, request, view):
-            return request.user.is_authenticated and (request.user.role == "owner" or request.user.role == "admin" or request.user.role == "member")
 
+    def has_permission(self, request, view):
+        return request.user.is_authenticated and (
+            request.user.role == "owner"
+            or request.user.role == "admin"
+            or request.user.role == "member"
+        )
+
+
+class CanDeleteMember(permissions.BasePermission):
+    """
+    Custom permission to only allow admins and owners to delete members.
+    """
+
+    def has_permission(self, request, view):
+        return request.user.is_authenticated and (
+            request.user.role == "admin" or request.user.role == "owner"
+        )
+
+    def has_object_permission(self, request, view, obj):
+        # Only allow if the user is an admin or owner
+        if not (request.user.role == "admin" or request.user.role == "owner"):
+            return False
+
+        # If user is an owner, they can only delete members from their tenant
+        if request.user.role == "owner":
+            return obj.tenant == request.user.tenant
+
+        # Admins can delete any member
+        return True


### PR DESCRIPTION
This pull request introduces significant changes to the `Tenant` model, serializers, and permissions to enhance file handling, improve permissions logic, and streamline code. The key updates include replacing `FileField` with `URLField` for file-related fields, adding new permissions for user roles, and updating serializers to handle file uploads and provide read-only URLs.

### Changes to file handling in the `Tenant` model and serializers:
* Replaced `FileField` with `URLField` for fields such as `logo`, `business_registration_certificate`, `business_license`, `tax_registration_certificate`, `bank_statement`, and `id_card` in the `Tenant` model. This simplifies file management by storing URLs instead of files directly. (`Backend/connectx_backend/tenants/models.py`, [[1]](diffhunk://#diff-95ea3ee5792eaafe00aecacfc68d1984d1f40e3f93b69f9aa8df8a433cf8872aL11-R11) [[2]](diffhunk://#diff-95ea3ee5792eaafe00aecacfc68d1984d1f40e3f93b69f9aa8df8a433cf8872aL41-R64)
* Updated `TenantSerializer` to accept file uploads via `FileField` for write operations and added corresponding read-only `URLField` properties for each file-related field. (`Backend/connectx_backend/tenants/serializers.py`, [[1]](diffhunk://#diff-55e3aa0785b59869a0a2aff8dc3c7ab6a09acd6dbaffb48c68ac0caeb7a3b0ecR53-R78) [[2]](diffhunk://#diff-55e3aa0785b59869a0a2aff8dc3c7ab6a09acd6dbaffb48c68ac0caeb7a3b0ecR87) [[3]](diffhunk://#diff-55e3aa0785b59869a0a2aff8dc3c7ab6a09acd6dbaffb48c68ac0caeb7a3b0ecR103-L139)
* Modified the `create` and `update` methods in `TenantSerializer` to upload files to external storage and save their URLs in the database. (`Backend/connectx_backend/tenants/serializers.py`, [[1]](diffhunk://#diff-55e3aa0785b59869a0a2aff8dc3c7ab6a09acd6dbaffb48c68ac0caeb7a3b0ecL42-R44) [[2]](diffhunk://#diff-55e3aa0785b59869a0a2aff8dc3c7ab6a09acd6dbaffb48c68ac0caeb7a3b0ecL159-R176)

### Updates to permissions and role-based access control:
* Added a new `CanDeleteMember` permission class to restrict member deletion to admins and tenant owners. Owners can only delete members from their own tenants. (`Backend/connectx_backend/users/permissions.py`, [Backend/connectx_backend/users/permissions.pyR3-R48](diffhunk://#diff-aacde391144e9206e1e01013ecdc574c4e68ac6f10a7b14ff6164cf46a5029f5R3-R48))
* Updated the `get_permissions` method in user views to use the `CanDeleteMember` permission for the `destroy` action. (`Backend/connectx_backend/users/views.py`, [Backend/connectx_backend/users/views.pyL87-R88](diffhunk://#diff-30fb0e05e70320716a02f540d3fa389c5cc2f7a0f7ddfb4907608da52e57422fL87-R88))
* Refactored the `destroy` method in user views to use the new permission logic and ensure only members can be deleted. (`Backend/connectx_backend/users/views.py`, [Backend/connectx_backend/users/views.pyL194-R200](diffhunk://#diff-30fb0e05e70320716a02f540d3fa389c5cc2f7a0f7ddfb4907608da52e57422fL194-R200))

### Minor improvements:
* Added a `has_permission` method to the `IsTenantOwner` permission class to check if a user is authenticated and has the "owner" role. (`Backend/connectx_backend/tenants/permissions.py`, [Backend/connectx_backend/tenants/permissions.pyR34-R37](diffhunk://#diff-082f5d4deb415d8bc2e333858ecf8735349fec0e4f16c38095e9ec75752e5f32R34-R37))…ocument storage

- Changed logo, business registration certificate, business license, tax registration certificate, bank statement, and ID card fields from FileField to URLField in the Tenant model for improved handling of document links.
- Updated TenantCreateSerializer and TenantSerializer to manage file uploads and provide read-only URL fields for the documents.
- Enhanced permission checks in IsTenantOwner and added CanDeleteMember permission to manage member deletion more effectively in user views.